### PR TITLE
fixed incorrect ordering of array size for M array (and MD as well)

### DIFF
--- a/csda_rpp/rpp.py
+++ b/csda_rpp/rpp.py
@@ -36,6 +36,9 @@ Glossary:
     volumes - number of sensitive volumes (e.g., number of bits)
     default_fast - default run mode is fast (computing/storing matrices)
     epsrel: epsrel argument passed to quad, dblquad numerical integration (relative precision)
+    ecludeH - used to exclude protons from LET spectrum and SEE rate for ion parts
+        fixed at False for proton parts, defaults to True for ion parts, but can override
+    
     
 Notes:
     Integration is done by adaptive quadrature using scipy.integrate.quad and 
@@ -760,7 +763,7 @@ class LB88(RPPChordLengthDist):
     
 class IonPartRPP(IonPart):
     """
-    part = IonPartRPP(h,cs=None,L0=None,W=None,S=None,slim=None,aspect=1,a=None,b=None,cld=None,volumes=1,default_fast=True,epsrel=1e-4)
+    part = IonPartRPP(h,cs=None,L0=None,W=None,S=None,slim=None,aspect=1,a=None,b=None,cld=None,volumes=1,default_fast=True,epsrel=1e-4,excludeH=True)
 
     Ion part modeled as right parallel piped (RPP) using chord length distribution (default LB88 method)
     
@@ -779,7 +782,7 @@ class IonPartRPP(IonPart):
     Public Methods:
         same as IonPart
     """
-    def __init__(self,h,cs=None,L0=None,W=None,S=None,slim=None,aspect=1,a=None,b=None,cld=None,volumes=1,default_fast=True,epsrel=1e-4):
+    def __init__(self,h,cs=None,L0=None,W=None,S=None,slim=None,aspect=1,a=None,b=None,cld=None,volumes=1,default_fast=True,epsrel=1e-4,excludeH=True):
         
         if cs is not None:
             slim = cs.slim            
@@ -824,7 +827,7 @@ class IonPartRPP(IonPart):
         Ap = (hcm*acm + hcm*bcm + acm*bcm)/2 # projected surface area
         xmax = np.sqrt(hcm**2 + acm**2 + bcm**2) # maximum path length
         # xnorm == hcm
-        super().__init__(cs,Ap,hcm,xmax,volumes=volumes,default_fast=default_fast,epsrel=epsrel)
+        super().__init__(cs,Ap,hcm,xmax,volumes=volumes,default_fast=default_fast,epsrel=epsrel,excludeH=excludeH)
         
         self.cld = cld
         self.h = h

--- a/csda_rpp/shielded_part.py
+++ b/csda_rpp/shielded_part.py
@@ -63,7 +63,7 @@ class ShieldedPart(object):
             icache - mapping from fluxZ to Z
             Z - array of Zs used in energy matrix and other matrices
             energy - energy matrix (NE,NZ)
-            LET - LET grid (NLET,NLET)
+            LET - LET grid (NLET,)
             D - incident spectrum to degraded spectrum matrices(NE,NE,NZ)
             M - degraded spectrum to LET spectrum matrices (NLET,NE,NZ) (ions)
             MD - incident energy spectrum to LET spectrum matrices (NLET,NE,NZ) (ions)
@@ -150,7 +150,7 @@ class ShieldedPart(object):
             
         # build matrices that convert from energy spectrum to LET spectrum
         # one per Z
-        M = np.zeros((energy.shape[0],len(LET),len(Z)))
+        M = np.zeros((len(LET),energy.shape[0],len(Z)))
         MD = np.zeros(M.shape)
         for (iz,z) in enumerate(Z):
             M[:,:,iz] = self.targetTable.get_Mcache(energy[:,iz],LET,species=self.targetTable.Z2sym[z])
@@ -588,7 +588,7 @@ if __name__ == '__main__':
     
     # make up fake flux
     # protons
-    pEgrid = np.exp(np.linspace(np.log(1e-1),np.log(1e5),1002))
+    pEgrid = np.exp(np.linspace(np.log(1e-1),np.log(1e5),501)) # use different size from LET
     pflux = np.exp(-pEgrid/10)
     t = np.linspace(0,1,20)    
     Egrid = np.zeros((len(pEgrid),len(Z)))


### PR DESCRIPTION
The error appears to only have been in the sizing of the M and MD arrays. M had the energy and LET sizes reversed. This worked as long as they were the same, but crashed when they were different. It had no effect on the results of the calculations, and was just an array allocation issue. The sizing is fixed, the associated docstring is fixed, and the demo now uses different sizes for energy and LET arrays to ensure this kind of thing will break the demo, too.

An additional fix has been applied: IonPartRPP lacked the excludeH argument to pass through to IonPart. This is fixed in the 2nd commit.