### PR TITLE
Var2hdf5 idl

### DIFF
--- a/var2hdf5/README.txt
+++ b/var2hdf5/README.txt
@@ -12,18 +12,18 @@ hdf52var reader function
 The variables are stored recursively under /var
 Each variable has a type attribute (see table below)
 
-type attr | python      | matlab      | (D)ataset or (G)roup, notes
-int       | int         | int64       | D signed long integer
-float     | float       | double      | D real number
-bool      | bool        | logical     | D boolean True or False (HDF5 enum)
-str       | str         | char        | D string as UTF-8/ASCII encoded bytes
-date      | datetime    | datenum     | D date/time stored as ISO 8601
-timedelta | timedelta   | double      | D time difference in seconds
-null      | None        | [] or zeros | D indicates absent/empty
-list      | list        | cell        | D list of items of heterogeneous types
-array     | np.ndarray  | N-D matrix  | D (N-D) list of variables of the same type
-dict      | dict        | struct      | G key-value pairs
-table     | np.ndarray  | struct      | G collection of named variables of same length
+type attr | python      | idl         | matlab      | (D)ataset or (G)roup, notes
+int       | int         | LONG        | int64       | D signed long integer
+float     | float       | DOUBLE      | double      | D real number
+bool      | bool        | BYTE        | logical     | D boolean True or False (HDF5 enum)
+str       | str         | STRING      | char        | D string as UTF-8/ASCII encoded bytes
+date      | datetime    | STRING      | char        | D date/time stored as ISO 8601
+timedelta | timedelta   | DOUBLE      | double      | D time difference in seconds
+null      | None        | UNDEFINED   | [] or zeros | D indicates absent/empty
+list      | list        | LIST        | cell        | D list of items of heterogeneous types
+array     | np.ndarray  | (array)     | N-D matrix  | D (N-D) list of variables of the same type
+dict      | dict        | HASH        | struct      | G key-value pairs
+table     | np.ndarray  | ORDEREDHASH | struct      | G collection of named variables of same length
 
 Additional notes
 
@@ -32,9 +32,9 @@ list:
     The value stored at the nominal location (e.g., /var/mylist) of a list 
       variable is the list number (#) in /__list_#__/.
     Attribute list_length specifies number of entries in list
-    List item names are zero-based, zero-padded integers with enough 
-      depth to hold all entries. So a list with 10 entries will have items 0..9
-      and a list with 100 entries will have items 00..99
+    List item names are zero-based, zero-padded integers as strings with enough 
+      depth to hold all entries. So a list with 10 entries will have items "0".."9"
+      and a list with 100 entries will have items "00".."99"
     List items can be any type, including other lists
     
 array:

--- a/var2hdf5/README.txt
+++ b/var2hdf5/README.txt
@@ -9,6 +9,9 @@ between computer languages.
 Each language will implement a var2hdf5 writer function and an 
 hdf52var reader function
 
+A global HDF5 file attribute VAR2HDF5_SPEC_VERSION (an integer, starting at 0)
+will be used to track changes to the file spec and allow reverse compatibility.
+
 The variables are stored recursively under /var
 Each variable has a type attribute (see table below)
 

--- a/var2hdf5/README.txt
+++ b/var2hdf5/README.txt
@@ -18,11 +18,11 @@ Each variable has a type attribute (see table below)
 type attr | python      | idl         | matlab      | (D)ataset or (G)roup, notes
 int       | int         | LONG        | int64       | D signed long integer
 float     | float       | DOUBLE      | double      | D real number
-bool      | bool        | BYTE        | logical     | D boolean True or False (HDF5 enum)
+bool      | bool        | BOOLEAN     | logical     | D boolean True or False (HDF5 enum)
 str       | str         | STRING      | char        | D string as UTF-8/ASCII encoded bytes
 date      | datetime    | STRING      | char        | D date/time stored as ISO 8601
 timedelta | timedelta   | DOUBLE      | double      | D time difference in seconds
-null      | None        | UNDEFINED   | [] or zeros | D indicates absent/empty
+null      | None        | list()      | [] or zeros | D indicates absent/empty
 list      | list        | LIST        | cell        | D list of items of heterogeneous types
 array     | np.ndarray  | (array)     | N-D matrix  | D (N-D) list of variables of the same type
 dict      | dict        | HASH        | struct      | G key-value pairs
@@ -44,6 +44,13 @@ array:
     Attribute subtype specifies the data type for the array entries
     Array of size 0 is written with subtype null
     
+dict:
+    key value pairs
+    Note that IDL, being case-insensitive, will write all structure tag names as upper
+      case. Conversely, a hash is used when reading dicts to preserve case-sensitivity.
+      IDL's !NULL type cannot be used because it is ignored by IDL in lists and structures.
+      E.g., [!NULL,3,2,!NULL,1] looks to IDL like [3,2,1], and {a:!NULL} is not allowed.
+
 table:
     For tabular data that has named columns
     Stored like a dict, but each variable's entry has a 'column' attribute

--- a/var2hdf5/README.txt
+++ b/var2hdf5/README.txt
@@ -12,6 +12,13 @@ hdf52var reader function
 A global HDF5 file attribute VAR2HDF5_SPEC_VERSION (an integer, starting at 0)
 will be used to track changes to the file spec and allow reverse compatibility.
 
+A global HDF5 file attribute 'writer' (a string) will be used to record what
+program wrote the HDF5 file. E.g., 'python/var2hdf5.py'
+
+Strings, including attributes, may be encoded differently by different languages.
+The reader will need to account for this when processing type and subtype attributes
+and when processing variables of type str and date.
+
 The variables are stored recursively under /var
 Each variable has a type attribute (see table below)
 

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -300,7 +300,7 @@ function hdf52var,filename,converter=conv_func
   return, _read_var(h5data.var,h5data,conv_func)
 end
 
-function _recursive_equals,a,b,path=in_path
+function _recursive_equals,a_in,b_in,path=in_path
   ; bool = _recursive_equals(a,b,path='/var')
   
   _init_var2hdf5
@@ -309,6 +309,8 @@ function _recursive_equals,a,b,path=in_path
   if n_elements(in_path) eq 0 then in_path = '/var'
   
   ; regularize types
+  a = a_in ; don't change original variable (pass by ref)
+  b = b_in ; don't change original variable (pass by ref)
   if size(a,/tname) eq 'STRUCT' then a = hash(a)
   if size(b,/tname) eq 'STRUCT' then b = hash(b)
   if typename(a) eq 'DICTIONARY' then a = hash(a.keys(),a.values())

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -1,0 +1,8 @@
+; var2hdf5.pro - write variables to and read variables from hdf5 files
+; Prinicpal author: Paul O'Brien
+; public functions:
+;    var2hdf5 - save a variable to an HDF5 file
+;    hdf52var - read a variable from an HDF5 file (for files created by var2hdf5)
+;    test - run several test cases that write, read, and compare
+    
+; placeholder for var2hdf5.pro which will provide two functions

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -26,20 +26,22 @@ function pad_int,i,padding
   ; str = pad_int(i,padding)
   ; creates string from integer i
   ; left pads with zeros until strlen(str) >= padding
-  key = strmid(i,2)
+  key = strtrim(i,2)
   while strlen(key) lt padding do key = '0'+key
   return,key
 end
 
-function _build_simple_var,variable,name,lists
-  ; var = _build_simple_var(variable,name,lists)
+function _build_simple_var,variable,name,conv_func,lists
+  ; var = _build_simple_var(variable,name,conv_func,lists)
   ; builds a structure that holds needed info for h5_create
   ; to create this simple variable
   ; simple variables are just scalars or arrays
+  ; conv_func is the converter provided to var2hdf5
   ; lists tracks list variables
   _init_var2hdf5
   common VAR2HDF5_COMMON
   
+  if conv_func then variable = conv_func(variable)
   tname = typename(variable)
   if isa(variable,/boolean) then type = 'bool' $
   else if tname eq 'STRING' then begin
@@ -49,52 +51,89 @@ function _build_simple_var,variable,name,lists
     if where(stregex(variable,iso8601,/BOOLEAN) eq !FALSE,/NULL) eq !NULL then type = 'datetime'
   endif else if ismember(tname,INT_TYPES) then type = 'int' $
   else if ismember(tname,FLOAT_TYPES) then type = 'float' $
-  else message,"Variable " + variable + " has unknown simple type " + tname
+  else message,"Variable " + name + " has unknown simple type " + tname
   
   var = {_NAME:name,_DATA:variable,_TYPE:'DATASET',$
     type:{_NAME:'type',_DATA:type,_TYPE:'ATTRIBUTE'}}
   return, var
 end
 
-function _build_var,variable,name,lists
-  ; var = _build_var(variable,name,lists)
+function _build_var,variable,name,conv_func,lists
+  ; var = _build_var(variable,name,conv_func,lists)
   ; builds a structure that holds needed info for h5_create
   ; to create this simple or complex variable
+  ; conv_func is the converter provided to var2hdf5
   ; lists tracks list variables
   
   _init_var2hdf5
   common VAR2HDF5_COMMON
   
-  tname1 = size(variable,/tname) ; simple type names
-  if ismember(tname1,SIMPLE_TYPES) then begin
-    return,_build_simple_var(variable,'var',lists)
+  if conv_func then variable = conv_func(variable)
+  
+  dims = size(variable,/dimensions)
+  if n_elements(dims) gt 1 then begin
+    ; reverse order of arrays for writing to file
+    variable = transpose(variable,reverse(indgen(n_elements(dims))))
   endif
   
+  tname1 = size(variable,/tname) ; simple type names
+  if ismember(tname1,SIMPLE_TYPES) then begin
+    return,_build_simple_var(variable,name,conv_func,lists)
+  endif
+
   tname2 = typename(variable) ; a bit more verbose on complex types (tname1 OBJREF)
   
   ; Cannot handle: tname1=COMPLEX, DCOMPLEX, POINTER, OBJREF
   ; Can handle: tname1=STRUCT, tname2=LIST, HASH, DICTIONARY, ORDEREDHASH
-  if tname1 eq 'STRUCT' then begin
-    var = {_NAME:variable,_TYPE:'GROUP'}
-    tags = tag_names(variable)
-    for i = 0,n_elements(tags)-1 do begin
-      val = _build_var(variable.(i),tags[i],lists)
-      var = create_struct(tags[i],val,var)
-    endfor
-  endif else if tname2 eq 'LIST' then begin
-    val = list()
+  var = {_NAME:name,_TYPE:'GROUP'}
+  type = 'dict'
+  nested = !FALSE
+  if tname2 eq 'LIST' then begin
     list_len = n_elements(variable)
-    padding = ceil(alog10(list_len)) ; required digits to express all entries
+    type = 'list'
+    ; add list_length attribute
+    var = create_struct('list_length',{_NAME:'list_length',_TYPE:'ATTRIBUTE',_DATA:n_elements(lists)},var)
+    val = list()
+    padding = ceil(alog10(1>list_len)) ; required digits to express all entries (1> means at least 1)
     for j=0,list_len-1 do begin
       key = pad_int(j,padding) ; left pad with zeros
-      val.add,_build_var(variable[i],key,lists)
+      val.add,_build_var(variable[j],key,conv_func,lists)
     endfor
     lists.add,val
-  endif else if tname2 eq 'HASH' then begin
-  endif else if tname2 eq 'DICTIONARY' then begin
-  endif else if tname2 eq 'ORDEREDHASH' then begin
+  endif else if (tname1 eq 'STRUCT') or ismember(tname2,['DICTIONARY','HASH','ORDEREDHASH']) then begin
+    type = 'table'
+    if tname2 ne 'ORDEREDHASH' then type = 'dict' ; without ordering, not a table
+    if tname1 eq 'STRUCT' then tags = tag_names(variable) $
+      else tags = variable.keys()
+    for i = 0,n_elements(tags)-1 do begin
+      if tname1 eq 'STRUCT' then val = variable.(i) $
+        else val = variable[tags[i]]
+      dims = size(val,/dimensions) ; not yet processed, so dimensions in original order
+      if i eq 0 then common_length = dims[0]
+      if dims[0] ne common_length then type = 'dict' ; 1st dim is not common_length long
+      if (n_elements(dims) gt 1) or (~ismember(typename(val),SIMPLE_TYPES)) then nested = !TRUE ; multidimensional or not simple type
+      val = _build_var(val,tags[i],conv_func,lists) ; convert to h5_create required struct
+      var = create_struct(tags[i],val,var)
+    endfor
+    if type eq 'table' then begin
+      ; add nested attribute
+      newvar = {nested:{_NAME:'nested',_TYPE:'ATTRIBUTE',_DATA:nested}}
+      tags2 = tag_names(var)
+      for i =0,n_elements(tags2)-1 do begin
+        val = var.(i)
+        if (size(val,/tname) eq 'STRUCT') && (val._TYPE ne 'ATTRIBUTE') then begin
+          ; add column attribute
+          column = where(tags eq tags2[i])
+          val = create_struct('column',{_NAME:'column',_TYPE:'ATTRIBUTE',_DATA:column[0]},val)
+        endif
+        newvar = create_struct(tags2[i],val,newvar)         
+      endfor
+      var = newvar
+    endif
   endif else message, "Unable to save " + name + " of type " + tname1 + '/' + tname2
   
+  ; add type attribute
+  var = create_struct('type',{_NAME:'type',_TYPE:'ATTRIBUTE',_DATA:type},var)
   return, var
 end
 
@@ -110,33 +149,25 @@ pro var2hdf5,variable,filename,converter=conv_func
   _init_var2hdf5
   common VAR2HDF5_COMMON
   
-  ; should be able to simply set conv_func = lambda(x:x)
-  ; but IDL just throws errors when calling lambda(5)
-  ; because it doesn't recognize lambda as a function pointer
-  ; executing examples from the help reveals exactly this error
-  ; IDL is buggy
-  has_converter = n_elements(conv_func) eq 0 
+  if n_elements(conv_func) eq 0 then conv_func = !FALSE
   
   ; remove file if it exists
   if file_test(filename) then begin
     file_delete,filename
   endif
   
-  
   lists = list()
   ; each entry in lists is a list of built-out variables (w/ metadata)
-  struct = _build_var(variable,'var',lists)
+  struct = _build_var(variable,'var',conv_func,lists)
   
   if n_elements(lists) gt 0 then begin
     for i = 0,n_elements(lists)-1 do begin
-      lname = '__list_' + strmid(i,2) + '__'
+      lname = '__list_' + strtrim(i,2) + '__'
       listi = lists[i]
       list_len = n_elements(listi)
-      s = {_NAME:lname,_TYPE:'GROUP',$
-           type:{_TYPE:'ATTRIBUTE',_DATA:'list'},$
-           list_length:{_TYPE:'ATTRIBUTE',_DATA:list_len}}
+      s = {_NAME:lname,_TYPE:'GROUP'}
       for j=0,list_len-1 do begin
-        s = create_struct('x'+listsi(j)._NAME,listi(j),s) ; prepend x to make valid IDL variable
+        s = create_struct('x'+listi[j]._NAME,listi[j],s) ; prepend x to make valid IDL variable
       endfor ; j - index into list[i]
       struct = create_struct(lname,s,struct)
     endfor ; i - index into lists    
@@ -149,14 +180,15 @@ pro var2hdf5,variable,filename,converter=conv_func
   h5_create,filename,top
 end
 
-function _read_var,rawvar
-; var = _read_var(rawvar)
+function _read_var,rawvar,h5data
+; var = _read_var(rawvar,h5data)
 ; recursively read and process rawvar
-; can't do this now because IDL < 8.8.1 has a bug that prevents
+; can't do this for python HDF5 files because of an IDL bug
 ; reading string attributes from HDF5 files. This is critical because
 ; the string attribute "type" is used to tell the reader what
 ; type the variable is supposed to have
-; IDL is so frustrating
+; but can read HDF5 files written by IDL
+  message,'Not implemented yet'
 end
 
 
@@ -177,16 +209,31 @@ function hdf52var,filename,converter
     codev = strtrim(VAR2HDF5_SPEC_VERSION,2) ; conver to string, w/o padding
     message,'VAR2HDF5_SPEC_VERSION '+ filev + '>' + codev  +' not suported'
   endif
-  return, _read_var(h5data.var)
+  return, _read_var(h5data.var,h5data)
 end
 
-pro test_hdf5
+function _recursive_equals,var1,var2,path=in_path
+  ; bool = _recursive_equals(var1,var2,path='/var')
+  if n_elements(in_path) eq 0 then path = '/var'
+  message,'Not implemented yet'
+  
+  print,'Unable to compare ',in_path,' types ',typename(var1),' and ', ypename(var2)
+  return, !FALSE
+end
 
+pro test
+  ; run a series of write/read tests for consistency
 
   tests = { $; each entry is test_name:expected_value
-    dict : {string:'foo',integer:3,real:4.5,boolean:!TRUE, $
+    struct : {string:'foo',integer:3,real:4.5,boolean:!TRUE, $
       date:timestamp(),list:list('foo',3,4.5,!TRUE,!VALUES.F_NAN), $
       dictionary:{a:1,b:2.5,c:'bar'}}, $
+    dict : dictionary('string','foo','integer',3,'real',4.5,'boolean',!TRUE, $
+      'date',timestamp(),'list',list('foo',3,4.5,!TRUE,!VALUES.F_NAN), $
+      'dictionary',{a:1,b:2.5,c:'bar'}), $
+    hash : hash({string:'foo',integer:3,real:4.5,boolean:!TRUE, $
+      date:timestamp(),list:list('foo',3,4.5,!TRUE,!VALUES.F_NAN), $
+      dictionary:{a:1,b:2.5,c:'bar'}}), $
     list : list('foo',3,4.5,boolean(0),{a:1,b:2.5,c:'bar'},!VALUES.F_NAN), $
     scalar : 4.5, $
     string : 'Hello World', $    
@@ -196,19 +243,33 @@ pro test_hdf5
     empty_list : list(), $
     empty_array : list(), $ ; UNDEFINED not allowed as dict entry value
     array : [[1,!VALUES.F_NAN,2],[3.0,4.1,5]], $
-    table : {integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE]}, $
-    nested : {integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE],subarray:make_array(3,3,value=1)} $ 
+    table : orderedhash({integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE]}), $
+    nested : orderedhash({integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE],$
+    subarray:[make_array(1,3,3,value=0),make_array(1,3,3,value=1)]}) $ 
   }
   
-  ; must run python test first to generate test files to read
-  ; python files are lowercase <tag>.h5 
-  
-  tnames = [tag_names(tests)]
+  tnames = tag_names(tests)
+  fails = 0
   for i = 0,n_elements(tnames)-1 do begin
-    filename = 'test_' + strlowcase(tnames[i]) + '.h5'
+    ;if ismember(strlowcase(tnames[i]),['table','nested']) then continue
+    key = tnames[i]
+    var = tests.(i)
+    filename = 'test_' + strlowcase(tnames[i]) + '_idl.h5'
     print,filename
+    var2hdf5,var,filename
+    continue ; cannot complete this test because hdf52var not written
+    var2 = hdf52var(filename)
+    continue ; cannot complete this test because _reverse_equals not written
+    if _recursive_equals(var,var2) then begin
+      print,key,': PASS'
+    endif else begin
+      print,key,'1: ',var
+      print,key,'2: ',var2
+      fails = fails + 1
+    endelse
   endfor
-  
+  print,'TOTAL FAILS: ',strtrim(fails,2)
+
 end
 
 

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -200,11 +200,9 @@ function _read_var,rawvar,h5data,conv_func
 ; rawvar is (sub)structure returned by h5_parse
 ; h5data is the top level structure returned by h5_parse
 ; conv_func is the converter provided to var2hdf5
-; can't do this for python HDF5 files because of an IDL bug
-; reading string attributes from HDF5 files. This is critical because
-; the string attribute "type" is used to tell the reader what
-; type the variable is supposed to have
-; but can read HDF5 files written by IDL
+; 
+; python HDF5 files can only be read by IDL 8.8.1 or higher 
+;  due to an IDL bug in prior versions of IDL
 
 ; types are: int, float, bool, str, date, timedelta, null, list, array, dict, table
   toptags = tag_names(h5data)
@@ -364,6 +362,7 @@ end
 
 pro test
   ; run a series of write/read tests for consistency
+  ; will read python test files if present
 
   tests = { $; each entry is test_name:expected_value
     struct : {string:'foo',integer:3,real:4.5,boolean:!TRUE, $
@@ -407,6 +406,18 @@ pro test
     endelse
   endfor
   print,'TOTAL FAILS: ',strtrim(fails,2)
+
+  ; now try to read python test files
+  py_count = 0
+  for i = 0,n_elements(tnames)-1 do begin
+    ;if ismember(strlowcase(tnames[i]),['table','nested']) then continue
+    filename = 'test_' + strlowcase(tnames[i]) + '.h5'
+    if ~file_test(filename) then continue ; file not present
+    print,'Reading python test file ',filename
+    var = hdf52var(filename)
+    py_count = py_count+1
+  endfor
+  print,'Python test files successfully read:',py_count
 
 end
 

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -175,6 +175,7 @@ pro var2hdf5,variable,filename,converter=conv_func
   
   top = {_TYPE:'GROUP',$
     VAR2HDF5_SPEC_VERSION:{_TYPE:'ATTRIBUTE',_DATA:VAR2HDF5_SPEC_VERSION},$
+    writer:{_NAME:'writer',_TYPE:'ATTRIBUTE',_DATA:'idl/'+file_basename(routine_filepath())},$
     VAR:struct}
 
   if n_elements(lists) gt 0 then begin

--- a/var2hdf5/var2hdf5.pro
+++ b/var2hdf5/var2hdf5.pro
@@ -6,3 +6,209 @@
 ;    test - run several test cases that write, read, and compare
     
 ; placeholder for var2hdf5.pro which will provide two functions
+
+pro _init_var2hdf5
+  ; initialize VAR2HDF5_COMMON common block
+  common VAR2HDF5_COMMON,VAR2HDF5_SPEC_VERSION,INT_TYPES,FLOAT_TYPES,SIMPLE_TYPES
+  VAR2HDF5_SPEC_VERSION = 0 ; integer
+  INT_TYPES = ['BYTE','INT','UINT','LONG','ULONG','LONG64','ULONG64']
+  FLOAT_TYPES = ['FLOAT','DOUBLE']
+  SIMPLE_TYPES = [INT_TYPES,FLOAT_TYPES,'STRING']
+end
+
+function ismember,entry,list
+  ; bool = ismember(entry,list)
+  ; returns true if list is found anywhere (exactly) in list
+  return, where(list eq entry,/NULL) ne !NULL
+end
+
+function pad_int,i,padding
+  ; str = pad_int(i,padding)
+  ; creates string from integer i
+  ; left pads with zeros until strlen(str) >= padding
+  key = strmid(i,2)
+  while strlen(key) lt padding do key = '0'+key
+  return,key
+end
+
+function _build_simple_var,variable,name,lists
+  ; var = _build_simple_var(variable,name,lists)
+  ; builds a structure that holds needed info for h5_create
+  ; to create this simple variable
+  ; simple variables are just scalars or arrays
+  ; lists tracks list variables
+  _init_var2hdf5
+  common VAR2HDF5_COMMON
+  
+  tname = typename(variable)
+  if isa(variable,/boolean) then type = 'bool' $
+  else if tname eq 'STRING' then begin
+    type = 'str'
+    ; now test for date-time string in ISO8601 YYYY-MM-DDTHH:MM:SS... format
+    iso8601 = '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'
+    if where(stregex(variable,iso8601,/BOOLEAN) eq !FALSE,/NULL) eq !NULL then type = 'datetime'
+  endif else if ismember(tname,INT_TYPES) then type = 'int' $
+  else if ismember(tname,FLOAT_TYPES) then type = 'float' $
+  else message,"Variable " + variable + " has unknown simple type " + tname
+  
+  var = {_NAME:name,_DATA:variable,_TYPE:'DATASET',$
+    type:{_NAME:'type',_DATA:type,_TYPE:'ATTRIBUTE'}}
+  return, var
+end
+
+function _build_var,variable,name,lists
+  ; var = _build_var(variable,name,lists)
+  ; builds a structure that holds needed info for h5_create
+  ; to create this simple or complex variable
+  ; lists tracks list variables
+  
+  _init_var2hdf5
+  common VAR2HDF5_COMMON
+  
+  tname1 = size(variable,/tname) ; simple type names
+  if ismember(tname1,SIMPLE_TYPES) then begin
+    return,_build_simple_var(variable,'var',lists)
+  endif
+  
+  tname2 = typename(variable) ; a bit more verbose on complex types (tname1 OBJREF)
+  
+  ; Cannot handle: tname1=COMPLEX, DCOMPLEX, POINTER, OBJREF
+  ; Can handle: tname1=STRUCT, tname2=LIST, HASH, DICTIONARY, ORDEREDHASH
+  if tname1 eq 'STRUCT' then begin
+    var = {_NAME:variable,_TYPE:'GROUP'}
+    tags = tag_names(variable)
+    for i = 0,n_elements(tags)-1 do begin
+      val = _build_var(variable.(i),tags[i],lists)
+      var = create_struct(tags[i],val,var)
+    endfor
+  endif else if tname2 eq 'LIST' then begin
+    val = list()
+    list_len = n_elements(variable)
+    padding = ceil(alog10(list_len)) ; required digits to express all entries
+    for j=0,list_len-1 do begin
+      key = pad_int(j,padding) ; left pad with zeros
+      val.add,_build_var(variable[i],key,lists)
+    endfor
+    lists.add,val
+  endif else if tname2 eq 'HASH' then begin
+  endif else if tname2 eq 'DICTIONARY' then begin
+  endif else if tname2 eq 'ORDEREDHASH' then begin
+  endif else message, "Unable to save " + name + " of type " + tname1 + '/' + tname2
+  
+  return, var
+end
+
+pro var2hdf5,variable,filename,converter=conv_func
+  ; var2hdf5,var,filename
+  ; var2hdf5,var,filename,converter=conv_func
+  ; write variable to hdf5 file
+  ; var - variable to write
+  ; filename - HDF5 filename to write
+  ; converter - function pointer that (conv_func) converts variables to HDF5-recognized types
+  ; calls var = conv_func(var) before trying to handle the variable
+  ; see README for conversion spec
+  _init_var2hdf5
+  common VAR2HDF5_COMMON
+  
+  ; should be able to simply set conv_func = lambda(x:x)
+  ; but IDL just throws errors when calling lambda(5)
+  ; because it doesn't recognize lambda as a function pointer
+  ; executing examples from the help reveals exactly this error
+  ; IDL is buggy
+  has_converter = n_elements(conv_func) eq 0 
+  
+  ; remove file if it exists
+  if file_test(filename) then begin
+    file_delete,filename
+  endif
+  
+  
+  lists = list()
+  ; each entry in lists is a list of built-out variables (w/ metadata)
+  struct = _build_var(variable,'var',lists)
+  
+  if n_elements(lists) gt 0 then begin
+    for i = 0,n_elements(lists)-1 do begin
+      lname = '__list_' + strmid(i,2) + '__'
+      listi = lists[i]
+      list_len = n_elements(listi)
+      s = {_NAME:lname,_TYPE:'GROUP',$
+           type:{_TYPE:'ATTRIBUTE',_DATA:'list'},$
+           list_length:{_TYPE:'ATTRIBUTE',_DATA:list_len}}
+      for j=0,list_len-1 do begin
+        s = create_struct('x'+listsi(j)._NAME,listi(j),s) ; prepend x to make valid IDL variable
+      endfor ; j - index into list[i]
+      struct = create_struct(lname,s,struct)
+    endfor ; i - index into lists    
+  endif
+  
+  top = {_TYPE:'GROUP',$
+    VAR2HDF5_SPEC_VERSION:{_TYPE:'ATTRIBUTE',_DATA:VAR2HDF5_SPEC_VERSION},$
+    VAR:struct}
+
+  h5_create,filename,top
+end
+
+function _read_var,rawvar
+; var = _read_var(rawvar)
+; recursively read and process rawvar
+; can't do this now because IDL < 8.8.1 has a bug that prevents
+; reading string attributes from HDF5 files. This is critical because
+; the string attribute "type" is used to tell the reader what
+; type the variable is supposed to have
+; IDL is so frustrating
+end
+
+
+function hdf52var,filename,converter
+  ;var = hdf52var(filename,converter=None)
+  ;read variable from hdf5 file
+  ;filename - HDF5 filename to read
+  ;converter - function pointer that converts variables to HDF5-recognized types
+  ;calls var = conveter(var,attrs) before trying to handle the variable
+  ;var - variable that was read
+  ;see README for conversion spec
+  
+  _init_var2hdf5
+  common VAR2HDF5_COMMON
+  h5data = h5_parse(filename,/read_data) ; read the entire hdf5 file
+  if h5data.VAR2HDF5_SPEC_VERSION._DATA gt VAR2HDF5_SPEC_VERSION then begin
+    filev = strtrim(h5data.VAR2HDF5_SPEC_VERSION._DATA,2) ; conver to string, w/o padding
+    codev = strtrim(VAR2HDF5_SPEC_VERSION,2) ; conver to string, w/o padding
+    message,'VAR2HDF5_SPEC_VERSION '+ filev + '>' + codev  +' not suported'
+  endif
+  return, _read_var(h5data.var)
+end
+
+pro test_hdf5
+
+
+  tests = { $; each entry is test_name:expected_value
+    dict : {string:'foo',integer:3,real:4.5,boolean:!TRUE, $
+      date:timestamp(),list:list('foo',3,4.5,!TRUE,!VALUES.F_NAN), $
+      dictionary:{a:1,b:2.5,c:'bar'}}, $
+    list : list('foo',3,4.5,boolean(0),{a:1,b:2.5,c:'bar'},!VALUES.F_NAN), $
+    scalar : 4.5, $
+    string : 'Hello World', $    
+    none : list(), $ ; list() has n_elements eq 0, serves as python None 
+    nan : !VALUES.F_NAN, $
+    null : make_array(4,value=!VALUES.F_NAN), $
+    empty_list : list(), $
+    empty_array : list(), $ ; UNDEFINED not allowed as dict entry value
+    array : [[1,!VALUES.F_NAN,2],[3.0,4.1,5]], $
+    table : {integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE]}, $
+    nested : {integer:[1,-1],real:[2.0,3.5],string:['foo','bar'],boolean:[!TRUE,!FALSE],subarray:make_array(3,3,value=1)} $ 
+  }
+  
+  ; must run python test first to generate test files to read
+  ; python files are lowercase <tag>.h5 
+  
+  tnames = [tag_names(tests)]
+  for i = 0,n_elements(tnames)-1 do begin
+    filename = 'test_' + strlowcase(tnames[i]) + '.h5'
+    print,filename
+  endfor
+  
+end
+
+

--- a/var2hdf5/var2hdf5.py
+++ b/var2hdf5/var2hdf5.py
@@ -239,9 +239,34 @@ def hdf52var(filename,converter=None):
         retrieve value from hdf5 file pointer
         """
         
+        def decode_str(var):
+            """
+            var = decode_str(var)
+                decode various string types
+                returns a str
+            """
+            if isinstance(var,str):
+                return var
+            return var.decode('utf-8')
+        def decode_date(var):
+            """
+            decodes date in YYYY-MM-DD:HH:MM:SS...Z format
+            a bit smarter than strptime: allows more precision on
+            seconds, allows with or without 'Z' suffix
+            """
+            var = decode_str(var)
+            parts = var.replace('Z','').replace('-',':').replace('T',':').split(':')
+            ints = [int(v) for v in parts[:5]]
+            parts[5] = float(parts[5])
+            parts[5] = round(parts[5]*1e6)/1e6 # round to nearest microsecond
+            s = int(np.floor(parts[5])) # seconds
+            us = int(round((parts[5]-s)*1e6)) # microseconds
+            date = dt.datetime(*ints,s,us)
+            return date
+        
         nonlocal converter
             
-        ty = fp[group].attrs['type']
+        ty = decode_str(fp[group].attrs['type'])
         if isinstance(fp[group],h5py.Dataset):
             # not a group, read & process dataset
             if hasattr(fp[group],'value'):
@@ -254,9 +279,9 @@ def hdf52var(filename,converter=None):
             if ty in ['int','float','bool']:
                 return var
             if ty == 'str':
-                return var.decode('utf-8')
+                return decode_str(var)
             if ty == 'date':
-                return dt.datetime.strptime(var.decode('utf-8'),"%Y-%m-%dT%H:%M:%S.%f")
+                return decode_date(var)
             if ty == 'timedelta':
                 return dt.timedelta(seconds=var)
             if ty == 'null':
@@ -264,11 +289,11 @@ def hdf52var(filename,converter=None):
             if ty == 'list':
                 return read_list(fp,var,fp[group].attrs['list_length'])
             if ty == 'array':
-                subtype = fp[group].attrs['subtype']
+                subtype = decode_str(fp[group].attrs['subtype'])
                 if subtype in ['int','float','bool']:
                     return var
                 if subtype == 'str':
-                    new_var = [v.decode('utf-8') for v in var.ravel()]
+                    new_var = [decode_str(v) for v in var.ravel()]
                     new_var = np.array(new_var,dtype='U')
                     new_var.shape = var.shape
                     return new_var
@@ -278,7 +303,7 @@ def hdf52var(filename,converter=None):
                         new_var.shape = var.shape
                     return new_var
                 if subtype == 'date':
-                    new_var = np.array([dt.datetime.strptime(v.decode('utf-8'), "%Y-%m-%dT%H:%M:%S") for v in var.ravel()])
+                    new_var = np.array([decode_date(v) for v in var.ravel()])
                     new_var.shape = var.shape
                     return new_var
                 if subtype == 'timedelta':
@@ -425,7 +450,16 @@ def test():
             print('%s: FAIL' % key)
             fails += 1
 
-    print('TOTAL FAILS: %d' % fails)            
+    print('TOTAL FAILS: %d' % fails)        
+
+    # now do IDL tests    
+    idl_count = 0
+    for file in os.listdir():
+        if not file.endswith('_idl.h5'): continue
+        print('Reading IDL file %s' % file)
+        var = hdf52var(file)
+        idl_count += 1
+    print('Total IDL files read: %d' % idl_count)
 
 
 if __name__ == '__main__':

--- a/var2hdf5/var2hdf5.py
+++ b/var2hdf5/var2hdf5.py
@@ -91,7 +91,7 @@ def var2hdf5(var,filename,converter=None):
                 return
 
             if isinstance(sample,(dt.datetime,dt.date))                    :
-                new_var = np.array([v.isotime() for v in var.ravel()])
+                new_var = np.array([v.isoformat() for v in var.ravel()])
                 new_var.shape = var.shape
                 fp[group] = new_var
                 fp[group].attrs['type'] = 'array'

--- a/var2hdf5/var2hdf5.py
+++ b/var2hdf5/var2hdf5.py
@@ -93,7 +93,7 @@ def var2hdf5(var,filename,converter=None):
             if isinstance(sample,(dt.datetime,dt.date))                    :
                 new_var = np.array([v.isoformat() for v in var.ravel()])
                 new_var.shape = var.shape
-                fp[group] = new_var
+                fp[group] = np.array(new_var,dtype='S')
                 fp[group].attrs['type'] = 'array'
                 fp[group].attrs['subtype'] = 'date'
                 return

--- a/var2hdf5/var2hdf5.py
+++ b/var2hdf5/var2hdf5.py
@@ -208,7 +208,7 @@ def hdf52var(filename,converter=None):
     """
     var = hdf52var(filename,converter=None)
     read variable from hdf5 file
-    filename - HDF5 filename to write
+    filename - HDF5 filename to read
     converter - function pointer that converts variables to HDF5-recognized types
     calls var = conveter(var,attrs) before trying to handle the variable
     var - variable that was read

--- a/var2hdf5/var2hdf5.py
+++ b/var2hdf5/var2hdf5.py
@@ -91,7 +91,7 @@ def var2hdf5(var,filename,converter=None):
                 return
 
             if isinstance(sample,(dt.datetime,dt.date))                    :
-                new_var = np.array([v.isoformat() for v in var.ravel()])
+                new_var = np.array([v.isoformat() for v in var.ravel()],dtype='S')
                 new_var.shape = var.shape
                 fp[group] = np.array(new_var,dtype='S')
                 fp[group].attrs['type'] = 'array'


### PR DESCRIPTION
Added IDL functionality. IDL can read and write its own HDF5 files. Unclear whether it can read python HDF5 files because the version of IDL I have (8.7) has a bug in reading string attributes created by python. IDL 8.8 may have fixed this.